### PR TITLE
Modernize golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,27 +2,22 @@ version: "2"
 linters:
   default: standard
   enable:
+    - bodyclose
+    - prealloc
     - unparam
+  exclusions:
+    paths:
+      - generated.*\.go
+      - client
+      - vendor
 
 formatters:
   enable:
-    - gofmt
+    - gofumpt
     - goimports
-  settings:
-    gofmt:
-      rewrite-rules:
-        - pattern: 'interface{}'
-          replacement: 'any'
 
 issues:
   max-same-issues: 100
-
-  exclude-files:
-    - generated.*\\.go
-
-  exclude-dirs:
-    - client
-    - vendor
 
 run:
   timeout: 10m

--- a/pkg/server/mail_deal_registration.go
+++ b/pkg/server/mail_deal_registration.go
@@ -23,7 +23,8 @@ import (
 )
 
 func NewDealRegistrationMailer(info *DealRegistrationInfo) mailer.Mailer {
-	src := fmt.Sprintf(`Hi,
+	src := fmt.Sprintf(
+		`Hi,
 A new deal has been registered with the following details:
 
 ## Partner

--- a/pkg/server/mail_kubedb_inquiry.go
+++ b/pkg/server/mail_kubedb_inquiry.go
@@ -23,7 +23,8 @@ import (
 )
 
 func NewKubeDBInquiryMailer(info *KubeDBInquiryInfo) mailer.Mailer {
-	src := fmt.Sprintf(`Hi,
+	src := fmt.Sprintf(
+		`Hi,
 A new KubeDB inquiry has been submitted with the following details:
 
 ## Customer

--- a/pkg/server/mail_kubedb_sales_qa.go
+++ b/pkg/server/mail_kubedb_sales_qa.go
@@ -58,7 +58,8 @@ func NewKubeDBSalesQAMailer(info *KubeDBSalesQAInfo) mailer.Mailer {
 		}
 	}
 
-	src := fmt.Sprintf(`Hi,
+	src := fmt.Sprintf(
+		`Hi,
 A new KubeDB sales QA result has been submitted with the following details:
 
 ## Prospect

--- a/pkg/server/qa.go
+++ b/pkg/server/qa.go
@@ -230,7 +230,8 @@ func (s *Server) startTest(c cache.Cache, ip string, configDocId, email string) 
 		}
 
 		docId, err := gdrive.CopyDoc(
-			s.srvDrive, s.srvDoc, cfg.QuestionTemplateDocId, folderId, docName, replacements)
+			s.srvDrive, s.srvDoc, cfg.QuestionTemplateDocId, folderId, docName, replacements,
+		)
 		if err != nil {
 			return err
 		}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -428,7 +428,8 @@ func (s *Server) Run() error {
 
 	if s.opts.EnableDripCampaign {
 		go func() {
-			if err := mailer.RunCampaigns(context.TODO(),
+			if err := mailer.RunCampaigns(
+				context.TODO(),
 				NewCommunitySignupCampaign(s.srvSheets, s.mg),
 				NewEnterpriseSignupCampaign(s.srvSheets, s.mg),
 				NewEnterpriseFirstTimeCampaign(s.srvSheets, s.mg),


### PR DESCRIPTION
## Summary

Modernize the `.golangci.yml` configuration for golangci-lint v2 and switch the configured formatter to gofumpt.

This aligns the linter with the build image (`ghcr.io/appscode/golang-dev`), where `gofmt` is a shim to gofumpt — so `make fmt` (via `hack/fmt.sh`'s `gofmt -s -w`) and the linter now enforce the same formatting. No change to `hack/fmt.sh` is needed.

### `.golangci.yml`
- Enable **`bodyclose`** and **`prealloc`** linters (`unparam` was already enabled).
- Move `exclude-files` / `exclude-dirs` out of the deprecated `issues:` block into **`linters.exclusions.paths`** — the correct location in golangci-lint v2.
- Fix the over-escaped exclusion regex `generated.*\\.go` → `generated.*\.go`.
- Switch the formatter from **`gofmt` → `gofumpt`** and drop the now-unneeded `interface{}` → `any` rewrite rule (gofumpt performs this itself at go1.18+).

### Resulting formatting
- gofumpt reformatting applied across the affected Go files.
