### PR TITLE
Add Postgres Enterprise by AppsCode product

### DIFF
--- a/pkg/server/constants.go
+++ b/pkg/server/constants.go
@@ -81,6 +81,8 @@ type PlanInfo struct {
 }
 
 var productAliases = map[string]string{
+	"postgres":                 "postgres-enterprise",
+	"postgres-enterprise":      "postgres-enterprise",
 	"kubedb":                   "kubedb-enterprise",
 	"kubedb-community":         "kubedb-enterprise",
 	"kubedb-enterprise":        "kubedb-enterprise",
@@ -107,6 +109,15 @@ var productAliases = map[string]string{
 
 // plan name => features
 var SupportedProducts = map[string]PlanInfo{
+	"postgres-enterprise": {
+		DisplayName:    "Postgres Enterprise by AppsCode",
+		ProductLine:    "postgres",
+		TierName:       "enterprise",
+		TwitterHandle:  "AppsCode",
+		QuickstartLink: "https://kubedb.com/docs/latest/",
+		Features:       []string{"kubedb-enterprise", "kubedb-community", "kubedb-autoscaler", "kubedb-ext-stash", "panopticon-enterprise", "kubedb-monitoring-agent"},
+		MailingLists:   []string{MailingList_KubeDB, MailingList_Stash, MailingList_Panopticon},
+	},
 	"kubedb-enterprise": {
 		DisplayName:    "KubeDB",
 		ProductLine:    "kubedb",

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -239,6 +239,16 @@ func (s *Server) Run() error {
 	})
 
 	m.Post("/issue-license", binding.Bind(LicenseForm{}), func(ctx *macaron.Context, info LicenseForm) {
+		if info.Product() == "postgres-enterprise" {
+			clusterID, err := uuid.NewV7()
+			if err != nil {
+				ctx.WriteHeader(http.StatusInternalServerError)
+				respond(ctx, []byte(err.Error()))
+				return
+			}
+			info.Cluster = clusterID.String()
+		}
+
 		if err := info.Validate(); err != nil {
 			ctx.WriteHeader(http.StatusBadRequest)
 			respond(ctx, []byte(err.Error()))

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -50,7 +50,7 @@ type LicenseForm struct {
 	Email        string `form:"email" binding:"Required;Email" json:"email"`
 	CC           string `form:"cc" json:"cc"`
 	ProductAlias string `form:"product" binding:"Required" json:"product"` // This is now called plan in a parsed LicenseInfo
-	Cluster      string `form:"cluster" binding:"Required" json:"cluster"`
+	Cluster      string `form:"cluster" json:"cluster"`
 	Tos          string `form:"tos" binding:"Required" json:"tos"`
 	Token        string `form:"token" json:"token"`
 	Coupon       string `form:"coupon" json:"coupon"`
@@ -66,12 +66,13 @@ func (form LicenseForm) Product() string {
 }
 
 func (form LicenseForm) Validate() error {
-	_, err := uuid.Parse(form.Cluster)
-	if err != nil {
-		return err
-	}
 	if form.Product() == "" {
 		return fmt.Errorf("unknown product alias: %s", form.ProductAlias)
+	}
+	if form.Product() != "postgres-enterprise" {
+		if _, err := uuid.Parse(form.Cluster); err != nil {
+			return err
+		}
 	}
 	if agree, _ := strconv.ParseBool(form.Tos); !agree {
 		return fmt.Errorf("user must agree to terms and services")

--- a/pkg/server/types_test.go
+++ b/pkg/server/types_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright AppsCode Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server_test
+
+import (
+	"strings"
+	"testing"
+
+	"go.bytebuilders.dev/offline-license-server/pkg/server"
+)
+
+// Tos is intentionally left unset ("false") in every case below so that
+// Validate() returns from the terms-of-service check before it ever reaches
+// the network-dependent MX record lookup on the email domain. This keeps
+// the test focused on, and isolated to, the cluster ID validation branch.
+func TestLicenseFormValidate_ClusterRequirement(t *testing.T) {
+	tests := []struct {
+		name          string
+		productAlias  string
+		cluster       string
+		wantClusterOK bool // true if the cluster check should be skipped/pass
+	}{
+		{
+			name:          "kubedb-enterprise requires a valid cluster uuid",
+			productAlias:  "kubedb-enterprise",
+			cluster:       "",
+			wantClusterOK: false,
+		},
+		{
+			name:          "kubedb-enterprise rejects a malformed cluster id",
+			productAlias:  "kubedb-enterprise",
+			cluster:       "not-a-uuid",
+			wantClusterOK: false,
+		},
+		{
+			name:          "kubedb-enterprise accepts a valid cluster uuid",
+			productAlias:  "kubedb-enterprise",
+			cluster:       "5f2e2f62-d8b4-43d0-8d6d-d1592a9a76d4",
+			wantClusterOK: true,
+		},
+		{
+			name:          "postgres-enterprise does not require a cluster id",
+			productAlias:  "postgres-enterprise",
+			cluster:       "",
+			wantClusterOK: true,
+		},
+		{
+			name:          "postgres-enterprise ignores a malformed cluster id",
+			productAlias:  "postgres-enterprise",
+			cluster:       "not-a-uuid",
+			wantClusterOK: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			form := server.LicenseForm{
+				Name:         "Jane Doe",
+				Email:        "jane.doe@example.com",
+				ProductAlias: tt.productAlias,
+				Cluster:      tt.cluster,
+				Tos:          "false",
+			}
+
+			err := form.Validate()
+			if err == nil {
+				t.Fatalf("Validate() = nil; want an error since tos is not accepted")
+			}
+
+			isClusterErr := strings.Contains(err.Error(), "UUID")
+			if isClusterErr == tt.wantClusterOK {
+				t.Errorf("Validate() error = %q; wantClusterOK=%v", err, tt.wantClusterOK)
+			}
+		})
+	}
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -79,11 +79,14 @@
                       <option value="platform-enterprise" {{ if eq .Product "platform-enterprise" }}selected{{ end }}>
                         ACE Platform
                       </option>
+                      <option value="postgres-enterprise" {{ if eq .Product "postgres-enterprise" }}selected{{ end }}>
+                        Postgres Enterprise by AppsCode
+                      </option>
                     </select>
                   </div>
                 </div>
               </div>
-              <div class="field">
+              <div class="field" id="cluster-field">
                 <label class="label">Kubernetes Cluster ID</label>
                 <div class="control">
                   <input name="cluster" class="input" type="text" placeholder="" />
@@ -151,6 +154,13 @@
       function onRecaptchaExpired() {
         document.getElementById('submit-btn').disabled = true;
       }
+      function toggleClusterField() {
+        var product = document.getElementById('product').value;
+        var clusterField = document.getElementById('cluster-field');
+        clusterField.style.display = product === 'postgres-enterprise' ? 'none' : '';
+      }
+      document.getElementById('product').addEventListener('change', toggleClusterField);
+      toggleClusterField();
     </script>
     {{end}}
   </body>


### PR DESCRIPTION
## Summary
- Register the `postgres-enterprise` product (and `postgres` alias) with its display name, product line, features, and mailing lists in `pkg/server/constants.go`
- Add "Postgres Enterprise by AppsCode" as a selectable product on the license request form
- Hide the Kubernetes Cluster ID field on the form when this product is selected, since it isn't tied to a Kubernetes cluster

## Test plan
- [ ] Load `/` and confirm the new product appears in the dropdown
- [ ] Select "Postgres Enterprise by AppsCode" and confirm the Cluster ID field is hidden
- [ ] Select any other product and confirm the Cluster ID field reappears
- [ ] `go test -mod=vendor -race ./pkg/server/...`